### PR TITLE
Local files should be opened as binary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ from artifactory import ArtifactoryPath
 path = ArtifactoryPath("http://repo.jfrog.org/artifactory/distributions/org/apache/tomcat/apache-tomcat-7.0.11.tar.gz")
     
 with path.open() as fd:
-    with open("tomcat.tar.gz", "w") as out:
+    with open("tomcat.tar.gz", "wb") as out:
         out.write(fd.read())
 ```
 

--- a/artifactory.py
+++ b/artifactory.py
@@ -843,7 +843,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         if self.is_dir():
             target = self / pathlib.Path(file_name).name
 
-        with open(file_name) as fobj:
+        with open(file_name, 'rb') as fobj:
             target.deploy(fobj, md5, sha1, parameters)
 
     def deploy_deb(self, file_name, distribution, component, architecture):


### PR DESCRIPTION
If you try to retrieve or deploy non-text files it will break if you don't open the local file as binary.
