### PR TITLE
Package multiple layout using matrix parameters

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -216,7 +216,7 @@ def encode_matrix_parameters(parameters):
 
     for param in iter(sorted(parameters)):
         if isinstance(parameters[param], (list, tuple)):
-            value = ','.join(parameters[param])
+            value = (';%s=' % (param)).join(parameters[param])
         else:
             value = parameters[param]
 

--- a/test.py
+++ b/test.py
@@ -29,7 +29,7 @@ class UtilTest(unittest.TestCase):
 
         s = artifactory.encode_matrix_parameters(params)
 
-        self.assertEqual(s, "baz=bar,quux;foo=asdf")
+        self.assertEqual(s, "baz=bar;baz=quux;foo=asdf")
 
 
 class ArtifactoryFlavorTest(unittest.TestCase):


### PR DESCRIPTION
# Package multiple layout using matrix parameters

To support package upload to mulitple distributions and/or
architecture the encode_matrix_parameters should be modified
to handle URL layout specified in Artifactory documentation

> For example, to upload package libatk1.0_i386.deb to both wheezy and trusty distributions, in both main and contrib components and both i386 and 64bit-arm architectures you would specify the following Target Path to upload using the UI:

```
pool/libatk1.0_i386.deb;deb.distribution=wheezy;deb.distribution=trusty;deb.component=main;deb.component=contrib;deb.architecture=i386;deb.architecture=64bit-arm
```

See Artifactory documentation: [Multiple layouts using Matrix Parameters](http://www.jfrog.com/confluence/display/RTF/Debian+Repositories#DebianRepositories-Specifyingmultiplelayouts)
