### PR TITLE
Revert change as requests contains its own, newer version of urllib3

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -34,10 +34,7 @@ import re
 import json
 import dateutil.parser
 import hashlib
-try:
-    import urllib3
-except ImportError:
-    import requests.packages.urllib3 as urllib3
+import requests.packages.urllib3 as urllib3
 try:
     import configparser
 except ImportError:


### PR DESCRIPTION
Talking this over with another engineer, I found that newer versions of requests contain their own version of urllib3 which probably should be used instead of the standalone version, eventhough this seems to work for my minimal testing.

It seems that if the requests module is installed/updated with pip, it will contain its urllib3 and the import should work. 

If the previous change passed a testsuite and makes sense to you, feel free to reject this pull request, or change the import so that the requests.packages.urllib3 is tried first.