### PR TITLE
make python 2.7.x compatible

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -34,7 +34,10 @@ import re
 import json
 import dateutil.parser
 import hashlib
-import requests.packages.urllib3 as urllib3
+try:
+    import requests.packages.urllib3 as urllib3
+except ImportError:
+    import urllib3
 try:
     import configparser
 except ImportError:


### PR DESCRIPTION
requests on python >=2.7.9 does not install urllib3 because it already exists in that version of python.  This is the suggested workaround