### PR TITLE
Add support for python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "3.3"
   - "2.7"
+  - "2.6"
 install: pip install -r requirements.txt
 script: python test.py
 

--- a/artifactory.py
+++ b/artifactory.py
@@ -952,7 +952,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         result for the special paths '.' and '..'.
         """
         for name in self._accessor.listdir(self):
-            if name in {'.', '..'}:
+            if name in ['.', '..']:
                 # Yielding a path object for these makes little sense
                 continue
             yield self._make_child_relpath(name)


### PR DESCRIPTION
This script is breaking on my python 2.6 box. I verified that it atleast compiles now using python2.6, and I added support for 2.6 to travis.

    python2.6 -m py_compile artifactory.py
