### PR TITLE
Support a different base URL for Artifactory (not ending in 'artifact…

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -279,6 +279,8 @@ class _ArtifactoryFlavour(pathlib._Flavour):
 
     is_supported = (True)
 
+    drive_split_point = 'artifactory'
+
     def parse_parts(self, parts):
         drv, root, parsed = super(_ArtifactoryFlavour, self).parse_parts(parts)
         return drv, root, parsed
@@ -295,13 +297,13 @@ class _ArtifactoryFlavour(pathlib._Flavour):
         drv = ''
         root = ''
 
-        mark = sep+'artifactory'+sep
+        mark = sep + self.drive_split_point + sep
         parts = part.split(mark)
 
         if len(parts) >= 2:
             drv = parts[0] + mark.rstrip('/')
             rest = '/' + mark.join(parts[1:])
-        elif part.endswith(sep+'artifactory'):
+        elif part.endswith(sep + self.drive_split_point):
             drv = part
             rest = ''
         else:

--- a/test.py
+++ b/test.py
@@ -108,6 +108,32 @@ class ArtifactoryFlavorTest(unittest.TestCase):
               ('http://example.com/artifactory', '/foo/',
                ['http://example.com/artifactory/foo/', 'bar', 'artifactory']))
 
+    def test_changed_root(self):
+        check = self._check_parse_parts
+
+        old_split_point = self.flavour.drive_split_point
+        self.flavour.drive_split_point = 'repository'
+
+        check(['.txt'],
+              ('', '', ['.txt']))
+
+        check(['http://b/repository/c/d.xml'],
+               ('http://b/repository', '/c/',
+                ['http://b/repository/c/', 'd.xml']))
+
+        check(['http://example.com/repository/foo'],
+              ('http://example.com/repository', '/foo/',
+               ['http://example.com/repository/foo/']))
+
+        check(['http://example.com/repository/foo/bar'],
+              ('http://example.com/repository', '/foo/',
+               ['http://example.com/repository/foo/', 'bar']))
+
+        check(['http://example.com/repository/foo/bar/artifactory'],
+              ('http://example.com/repository', '/foo/',
+               ['http://example.com/repository/foo/', 'bar', 'artifactory']))
+
+        self.flavour.drive_split_point = old_split_point
 
 class PureArtifactoryPathTest(unittest.TestCase):
     cls = artifactory.PureArtifactoryPath


### PR DESCRIPTION
…ory')

There appears to already be a pull request to support a similar thing through the configuration file, but this allows to specify the split point through code.  I think perhaps a mix of the two would be best.