### PR TITLE
Modernize code a little

### DIFF
--- a/int_test.py
+++ b/int_test.py
@@ -2,16 +2,21 @@
 
 import os
 import sys
-import StringIO
 
 import unittest
 import multiprocessing
 import tempfile
 import artifactory
-import ConfigParser
+
+if sys.version_info[0] < 3:
+    import StringIO as io
+    import ConfigParser as configparser
+else:
+    import io
+    import configparser
 
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 
 config.read("test.cfg")
 
@@ -133,7 +138,7 @@ class ArtifactoryPathTest(unittest.TestCase):
         if p.exists():
             p.unlink()
 
-        s = StringIO.StringIO()
+        s = io.StringIO()
         s.write("Some test string")
 
         p.deploy(s)
@@ -186,7 +191,7 @@ class ArtifactoryPathTest(unittest.TestCase):
         if p.exists():
             p.rmdir()
 
-        s = StringIO.StringIO()
+        s = io.StringIO()
         s.write("Some test string")
 
         p.deploy(s)

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import sys
 
 try:
     from setuptools import setup
@@ -44,12 +45,14 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Software Development :: Libraries',
         'Topic :: System :: Filesystems',
     ],
     url='http://github.com/parallels/artifactory',
     download_url='http://github.com/parallels/artifactory',
-    install_requires=['pathlib', 'requests', 'python-dateutil'],
+    install_requires=['requests', 'python-dateutil'] + ['pathlib'] if sys.version_info[0] < 3 or sys.version_info[1] < 4 else [],
     zip_safe=False,
     package_data={'': ['README.md']}
 )


### PR DESCRIPTION
Trying to write a ebuild for my Gentoo system, I've noticed a redundant dependency on `pathlib`. It doesn't needed for Python >= 3.4, since it's a part of standard Python nowadays.

Trying to `py.test` the code, I had also fix incorrect `import` in `int_test.py`… but that wasn't help much :( -- tests code seem broken anyway...
