### PR TITLE
Add session, fix Windows test 

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,27 @@ path = ArtifactoryPath(
 path.touch()
 ```
 
+## Session ##
+
+To re-use the established connection, you can pass ```session``` parameter to ArtifactoryPath:
+
+```python
+from artifactory import ArtifactoryPath
+import requests
+ses = requests.Session()
+ses.auth = ('username', 'password')
+path = ArtifactoryPath(
+    "http://my-artifactory/artifactory/myrepo/my-path-1",
+    sesssion=ses)
+path.touch()
+
+path = ArtifactoryPath(
+    "http://my-artifactory/artifactory/myrepo/my-path-2",
+    sesssion=ses)
+path.touch()
+```
+
+
 ## SSL Cert Verification Options ##
 See [Requests - SSL verification](http://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification) for more details.  
 

--- a/artifactory.py
+++ b/artifactory.py
@@ -863,6 +863,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         cfg_entry = get_global_config_entry(obj.drive)
         obj.auth = kwargs.get('auth', None)
         obj.cert = kwargs.get('cert', None)
+        obj.session = kwargs.get('session', None)
 
         if obj.auth is None and cfg_entry:
             obj.auth = (cfg_entry['username'], cfg_entry['password'])
@@ -877,8 +878,9 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         else:
             obj.verify = True
 
-        obj.session = requests.session()
-        obj.session.auth = obj.auth
+        if obj.session is None:
+            obj.session = requests.Session()
+            obj.session.auth = obj.auth
 
         return obj
 

--- a/artifactory.py
+++ b/artifactory.py
@@ -34,6 +34,7 @@ import re
 import json
 import dateutil.parser
 import hashlib
+
 try:
     import requests.packages.urllib3 as urllib3
 except ImportError:
@@ -42,7 +43,6 @@ try:
     import configparser
 except ImportError:
     import ConfigParser as configparser
-
 
 default_config_path = '~/.artifactory_python.cfg'
 global_config = None
@@ -220,6 +220,7 @@ class HTTPResponseWrapper(object):
     since the stream is not rewindable, by the time it tries to send
     actual content, there is nothing left in the stream.
     """
+
     def __init__(self, obj):
         self.obj = obj
 
@@ -327,10 +328,10 @@ class _ArtifactoryFlavour(pathlib._Flavour):
 
         base = get_global_base_url(part)
         if base and without_http_prefix(part).startswith(without_http_prefix(base)):
-            mark = without_http_prefix(base).rstrip(sep)+sep
+            mark = without_http_prefix(base).rstrip(sep) + sep
             parts = part.split(mark)
         else:
-            mark = sep+'artifactory'+sep
+            mark = sep + 'artifactory' + sep
             parts = part.split(mark)
 
         if len(parts) >= 2:
@@ -409,51 +410,49 @@ class _ArtifactoryAccessor(pathlib._Accessor):
     """
     Implements operations with Artifactory REST API
     """
-    def rest_get(self, url, params=None, headers=None, auth=None, verify=True, cert=None):
+
+    def rest_get(self, url, params=None, headers=None, session=None, verify=True, cert=None):
         """
-        Perform a GET request to url with optional authentication
+        Perform a GET request to url with requests.session
         """
-        res = requests.get(url, params=params, headers=headers, auth=auth, verify=verify,
-                           cert=cert)
+        res = session.get(url, params=params, headers=headers, verify=verify, cert=cert)
         return res.text, res.status_code
 
-    def rest_put(self, url, params=None, headers=None, auth=None, verify=True, cert=None):
+    def rest_put(self, url, params=None, headers=None, session=None, verify=True, cert=None):
         """
-        Perform a PUT request to url with optional authentication
+        Perform a PUT request to url with requests.session
         """
-        res = requests.put(url, params=params, headers=headers, auth=auth, verify=verify,
-                           cert=cert)
+        res = session.put(url, params=params, headers=headers, verify=verify, cert=cert)
         return res.text, res.status_code
 
-    def rest_post(self, url, params=None, headers=None, auth=None, verify=True, cert=None):
+    def rest_post(self, url, params=None, headers=None, session=None, verify=True, cert=None):
         """
-        Perform a PUT request to url with optional authentication
+        Perform a POST request to url with requests.session
         """
-        res = requests.post(url, params=params, headers=headers, auth=auth, verify=verify,
-                            cert=cert)
+        res = session.post(url, params=params, headers=headers, verify=verify, cert=cert)
         return res.text, res.status_code
 
-    def rest_del(self, url, params=None, auth=None, verify=True, cert=None):
+    def rest_del(self, url, params=None, session=None, verify=True, cert=None):
         """
-        Perform a DELETE request to url with optional authentication
+        Perform a DELETE request to url with requests.session
         """
-        res = requests.delete(url, params=params, auth=auth, verify=verify, cert=cert)
+        res = session.delete(url, params=params, verify=verify, cert=cert)
         return res.text, res.status_code
 
-    def rest_put_stream(self, url, stream, headers=None, auth=None, verify=True, cert=None):
+    def rest_put_stream(self, url, stream, headers=None, session=None, verify=True, cert=None):
         """
-        Perform a chunked PUT request to url with optional authentication
+        Perform a chunked PUT request to url with requests.session
         This is specifically to upload files.
         """
-        res = requests.put(url, headers=headers, auth=auth, data=stream, verify=verify, cert=cert)
+        res = session.put(url, headers=headers, data=stream, verify=verify, cert=cert)
         return res.text, res.status_code
 
-    def rest_get_stream(self, url, auth=None, verify=True, cert=None):
+    def rest_get_stream(self, url, session=None, verify=True, cert=None):
         """
-        Perform a chunked GET request to url with optional authentication
+        Perform a chunked GET request to url with requests.session
         This is specifically to download files.
         """
-        res = requests.get(url, auth=auth, stream=True, verify=verify, cert=cert)
+        res = session.get(url, stream=True, verify=verify, cert=cert)
         return res.raw, res.status_code
 
     def get_stat_json(self, pathobj):
@@ -465,7 +464,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
                         'api/storage',
                         str(pathobj.relative_to(pathobj.drive)).strip('/')])
 
-        text, code = self.rest_get(url, auth=pathobj.auth, verify=pathobj.verify,
+        text, code = self.rest_get(url, session=pathobj.session, verify=pathobj.verify,
                                    cert=pathobj.cert)
         if code == 404 and "Unable to find item" in text:
             raise OSError(2, "No such file or directory: '%s'" % url)
@@ -564,8 +563,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
             raise OSError(17, "File exists: '%s'" % str(pathobj))
 
         url = str(pathobj) + '/'
-        text, code = self.rest_put(url, auth=pathobj.auth, verify=pathobj.verify,
-                                   cert=pathobj.cert)
+        text, code = self.rest_put(url, session=pathobj.session, verify=pathobj.verify, cert=pathobj.cert)
 
         if not code == 201:
             raise RuntimeError("%s %d" % (text, code))
@@ -581,8 +579,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
 
         url = str(pathobj) + '/'
 
-        text, code = self.rest_del(url, auth=pathobj.auth, verify=pathobj.verify,
-                                   cert=pathobj.cert)
+        text, code = self.rest_del(url, session=pathobj.session, verify=pathobj.verify, cert=pathobj.cert)
 
         if code not in [200, 202, 204]:
             raise RuntimeError("Failed to delete directory: '%s'" % text)
@@ -597,7 +594,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
             raise OSError(1, "Operation not permitted: '%s'" % str(pathobj))
 
         url = str(pathobj)
-        text, code = self.rest_del(url, auth=pathobj.auth, verify=pathobj.verify,
+        text, code = self.rest_del(url, session=pathobj.session, verify=pathobj.verify,
                                    cert=pathobj.cert)
 
         if code not in [200, 202, 204]:
@@ -614,8 +611,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
             return
 
         url = str(pathobj)
-        text, code = self.rest_put(url, auth=pathobj.auth, verify=pathobj.verify,
-                                   cert=pathobj.cert)
+        text, code = self.rest_put(url, session=pathobj.session, verify=pathobj.verify, cert=pathobj.cert)
 
         if not code == 201:
             raise RuntimeError("%s %d" % (text, code))
@@ -653,7 +649,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
         seek()
         """
         url = str(pathobj)
-        raw, code = self.rest_get_stream(url, auth=pathobj.auth, verify=pathobj.verify,
+        raw, code = self.rest_get_stream(url, session=pathobj.session, verify=pathobj.verify,
                                          cert=pathobj.cert)
 
         if not code == 200:
@@ -684,7 +680,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
         text, code = self.rest_put_stream(url,
                                           fobj,
                                           headers=headers,
-                                          auth=pathobj.auth,
+                                          session=pathobj.session,
                                           verify=pathobj.verify,
                                           cert=pathobj.cert)
 
@@ -704,7 +700,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
 
         text, code = self.rest_post(url,
                                     params=params,
-                                    auth=src.auth,
+                                    session=src.session,
                                     verify=src.verify,
                                     cert=src.cert)
 
@@ -723,7 +719,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
 
         text, code = self.rest_post(url,
                                     params=params,
-                                    auth=src.auth,
+                                    session=src.session,
                                     verify=src.verify,
                                     cert=src.cert)
 
@@ -742,7 +738,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
 
         text, code = self.rest_get(url,
                                    params=params,
-                                   auth=pathobj.auth,
+                                   session=pathobj.session,
                                    verify=pathobj.verify,
                                    cert=pathobj.cert)
 
@@ -770,7 +766,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
 
         text, code = self.rest_put(url,
                                    params=params,
-                                   auth=pathobj.auth,
+                                   session=pathobj.session,
                                    verify=pathobj.verify,
                                    cert=pathobj.cert)
 
@@ -797,7 +793,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
 
         text, code = self.rest_del(url,
                                    params=params,
-                                   auth=pathobj.auth,
+                                   session=pathobj.session,
                                    verify=pathobj.verify,
                                    cert=pathobj.cert)
 
@@ -852,7 +848,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
     """
     # Pathlib limits what members can be present in 'Path' class,
     # so authentication information has to be added via __slots__
-    __slots__ = ('auth', 'verify', 'cert')
+    __slots__ = ('auth', 'verify', 'cert', 'session')
 
     def __new__(cls, *args, **kwargs):
         """
@@ -881,6 +877,9 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         else:
             obj.verify = True
 
+        obj.session = requests.session()
+        obj.session.auth = obj.auth
+
         return obj
 
     def _init(self, *args, **kwargs):
@@ -898,6 +897,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         obj.auth = self.auth
         obj.verify = self.verify
         obj.cert = self.cert
+        obj.session = self.session
         return obj
 
     def with_name(self, name):
@@ -908,6 +908,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         obj.auth = self.auth
         obj.verify = self.verify
         obj.cert = self.cert
+        obj.session = self.session
         return obj
 
     def with_suffix(self, suffix):
@@ -918,6 +919,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         obj.auth = self.auth
         obj.verify = self.verify
         obj.cert = self.cert
+        obj.session = self.session
         return obj
 
     def relative_to(self, *other):
@@ -930,6 +932,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         obj.auth = self.auth
         obj.verify = self.verify
         obj.cert = self.cert
+        obj.session = self.session
         return obj
 
     def joinpath(self, *args):
@@ -943,6 +946,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         obj.auth = self.auth
         obj.verify = self.verify
         obj.cert = self.cert
+        obj.session = self.session
         return obj
 
     def __truediv__(self, key):
@@ -953,6 +957,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         obj.auth = self.auth
         obj.verify = self.verify
         obj.cert = self.cert
+        obj.session = self.session
         return obj
 
     def __rtruediv__(self, key):
@@ -963,6 +968,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         obj.auth = self.auth
         obj.verify = self.verify
         obj.cert = self.cert
+        obj.session = self.session
         return obj
 
     if sys.version_info < (3,):
@@ -974,6 +980,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         obj.auth = self.auth
         obj.verify = self.verify
         obj.cert = self.cert
+        obj.session = self.session
         return obj
 
     def _make_child_relpath(self, args):
@@ -981,6 +988,7 @@ class ArtifactoryPath(pathlib.Path, PureArtifactoryPath):
         obj.auth = self.auth
         obj.verify = self.verify
         obj.cert = self.cert
+        obj.session = self.session
         return obj
 
     def __iter__(self):

--- a/test.py
+++ b/test.py
@@ -281,7 +281,7 @@ class ArtifactoryAccessorTest(unittest.TestCase):
 
         url = "http://b/artifactory/c/d;baz=quux;foo=bar"
 
-        a.rest_put_stream.assert_called_with(url, f, headers={}, auth=None, verify=True, cert=None)
+        a.rest_put_stream.assert_called_with(url, f, headers={}, session=p.session, verify=True, cert=None)
 
 
 class ArtifactoryPathTest(unittest.TestCase):

--- a/test.py
+++ b/test.py
@@ -335,30 +335,34 @@ class TestArtifactoryConfig(unittest.TestCase):
               "username=foo\n" + \
               "password=bar\n"
 
-        with tempfile.NamedTemporaryFile(mode='w+') as tf:
+        tf = tempfile.NamedTemporaryFile(mode='w+', delete=False)
+        try:
             tf.write(cfg)
             tf.flush()
+            tf.close()
             cfg = artifactory.read_config(tf.name)
+        finally:
+            os.remove(tf.name)
 
-            c = artifactory.get_config_entry(cfg, 'foo.net/artifactory')
-            self.assertEqual(c['username'], 'admin')
-            self.assertEqual(c['password'], 'ilikerandompasswords')
-            self.assertEqual(c['verify'], False)
-            self.assertEqual(c['cert'],
-                             os.path.expanduser('~/path-to-cert'))
+        c = artifactory.get_config_entry(cfg, 'foo.net/artifactory')
+        self.assertEqual(c['username'], 'admin')
+        self.assertEqual(c['password'], 'ilikerandompasswords')
+        self.assertEqual(c['verify'], False)
+        self.assertEqual(c['cert'],
+                         os.path.expanduser('~/path-to-cert'))
 
-            c = artifactory.get_config_entry(cfg, 'http://bar.net/artifactory')
-            self.assertEqual(c['username'], 'foo')
-            self.assertEqual(c['password'], 'bar')
-            self.assertEqual(c['verify'], True)
+        c = artifactory.get_config_entry(cfg, 'http://bar.net/artifactory')
+        self.assertEqual(c['username'], 'foo')
+        self.assertEqual(c['password'], 'bar')
+        self.assertEqual(c['verify'], True)
 
-            c = artifactory.get_config_entry(cfg, 'bar.net/artifactory')
-            self.assertEqual(c['username'], 'foo')
-            self.assertEqual(c['password'], 'bar')
+        c = artifactory.get_config_entry(cfg, 'bar.net/artifactory')
+        self.assertEqual(c['username'], 'foo')
+        self.assertEqual(c['password'], 'bar')
 
-            c = artifactory.get_config_entry(cfg, 'https://bar.net/artifactory')
-            self.assertEqual(c['username'], 'foo')
-            self.assertEqual(c['password'], 'bar')
+        c = artifactory.get_config_entry(cfg, 'https://bar.net/artifactory')
+        self.assertEqual(c['username'], 'foo')
+        self.assertEqual(c['password'], 'bar')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello! We use LDAP-auth in Artifactory, and every http-session connection establishment slows down the work, when we done something like this or bulk remove artifacts
```python
    for p in path.glob('**/*'):
        print(p)
```
I have added requests.session to object and operating time decreases

Also fix test on Windows system