### PR TITLE
Cowlinator/http codes to user

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -470,7 +470,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
         if code == 404 and "Unable to find item" in text:
             raise OSError(2, "No such file or directory: '%s'" % url)
         if code != 200:
-            raise RuntimeError(text)
+            raise RuntimeError("%d '%s'" % (code, text))
 
         return json.loads(text)
 
@@ -585,7 +585,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
                                    cert=pathobj.cert)
 
         if code not in [200, 202, 204]:
-            raise RuntimeError("Failed to delete directory: '%s'" % text)
+            raise RuntimeError("Failed to delete directory: %d '%s'" % (code, text))
 
     def unlink(self, pathobj):
         """
@@ -657,7 +657,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
                                          cert=pathobj.cert)
 
         if not code == 200:
-            raise RuntimeError("%d" % code)
+            raise RuntimeError("%d '%s'" % (code, text))
 
         return raw
 
@@ -689,7 +689,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
                                           cert=pathobj.cert)
 
         if code not in [200, 201]:
-            raise RuntimeError("%s" % text)
+            raise RuntimeError("%d '%s'" % (code, text))
 
     def copy(self, src, dst, suppress_layouts=False):
         """
@@ -709,7 +709,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
                                     cert=src.cert)
 
         if code not in [200, 201]:
-            raise RuntimeError("%s" % text)
+            raise RuntimeError("%d '%s'" % (code, text))
 
     def move(self, src, dst):
         """
@@ -728,7 +728,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
                                     cert=src.cert)
 
         if code not in [200, 201]:
-            raise RuntimeError("%s" % text)
+            raise RuntimeError("%d '%s'" % (code, text))
 
     def get_properties(self, pathobj):
         """
@@ -751,7 +751,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
         if code == 404 and "No properties could be found" in text:
             return {}
         if code != 200:
-            raise RuntimeError(text)
+            raise RuntimeError("%d '%s'" % (code, text))
 
         return json.loads(text)['properties']
 
@@ -777,7 +777,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
         if code == 404 and "Unable to find item" in text:
             raise OSError(2, "No such file or directory: '%s'" % url)
         if code != 204:
-            raise RuntimeError(text)
+            raise RuntimeError("%d '%s'" % (code, text))
 
     def del_properties(self, pathobj, props, recursive):
         """
@@ -804,7 +804,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
         if code == 404 and "Unable to find item" in text:
             raise OSError(2, "No such file or directory: '%s'" % url)
         if code != 204:
-            raise RuntimeError(text)
+            raise RuntimeError("%d '%s'" % (code, text))
 
 
 _artifactory_accessor = _ArtifactoryAccessor()

--- a/artifactory.py
+++ b/artifactory.py
@@ -657,7 +657,7 @@ class _ArtifactoryAccessor(pathlib._Accessor):
                                          cert=pathobj.cert)
 
         if not code == 200:
-            raise RuntimeError("%d '%s'" % (code, text))
+            raise RuntimeError("Failed to open stream. Status code %d" % code)
 
         return raw
 

--- a/test.py
+++ b/test.py
@@ -335,9 +335,16 @@ class TestArtifactoryConfig(unittest.TestCase):
               "username=foo\n" + \
               "password=bar\n"
 
-        with tempfile.NamedTemporaryFile(mode='w+') as tf:
-            tf.write(cfg)
-            tf.flush()
+        tf = tempfile.NamedTemporaryFile(mode='w+', delete=False)
+        try:
+            with tf:
+                tf.write(cfg)
+                tf.flush()
+        except Exception as e:
+            os.remove(tf.name)
+            raise e
+
+        try:
             cfg = artifactory.read_config(tf.name)
 
             c = artifactory.get_config_entry(cfg, 'foo.net/artifactory')
@@ -359,6 +366,8 @@ class TestArtifactoryConfig(unittest.TestCase):
             c = artifactory.get_config_entry(cfg, 'https://bar.net/artifactory')
             self.assertEqual(c['username'], 'foo')
             self.assertEqual(c['password'], 'bar')
+        finally:
+            os.remove(tf.name)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As a user, it has been very frustrating when artifactory.py silently swallows http error codes.
This PR ensures that all http-related exceptions include information about http error codes.
This PR also includes a fix for an unrelated test case, which had sometimes falsely failed when a temporary file opened for writing was subsequently opened for reading.