### PR TITLE
Add support to send Custom CA certs in case of self signed certificates.

### DIFF
--- a/artifactory.py
+++ b/artifactory.py
@@ -80,7 +80,7 @@ def read_config(config_path=default_config_path):
     for section in p.sections():
         username = p.get(section, 'username') if p.has_option(section, 'username') else None
         password = p.get(section, 'password') if p.has_option(section, 'password') else None
-        if p.has_option(section, 'verify')
+        if p.has_option(section, 'verify'):
             try:
                 verify = p.getboolean(section, 'verify')
             except ValueError:

--- a/artifactory.py
+++ b/artifactory.py
@@ -80,7 +80,14 @@ def read_config(config_path=default_config_path):
     for section in p.sections():
         username = p.get(section, 'username') if p.has_option(section, 'username') else None
         password = p.get(section, 'password') if p.has_option(section, 'password') else None
-        verify = p.get(section, 'verify') if p.has_option(section, 'verify') else True
+        if p.has_option(section, 'verify')
+            try:
+                verify = p.getboolean(section, 'verify')
+            except ValueError:
+                # Verify CA cert path may contain '~'
+                verify = os.path.expanduser(p.get(section, 'verify'))
+        else: 
+            verify = True
         cert = p.get(section, 'cert') if p.has_option(section, 'cert') else None
 
         result[section] = {'username': username,

--- a/artifactory.py
+++ b/artifactory.py
@@ -61,7 +61,7 @@ def read_config(config_path=default_config_path):
       [https://artifactory-instance.local/artifactory]
       username = foo
       password = @dmin
-      verify = false
+      verify = true/false or ~/path-to-ca-chain
       cert = ~/path-to-cert
 
     config-path - specifies where to read the config from
@@ -80,7 +80,7 @@ def read_config(config_path=default_config_path):
     for section in p.sections():
         username = p.get(section, 'username') if p.has_option(section, 'username') else None
         password = p.get(section, 'password') if p.has_option(section, 'password') else None
-        verify = p.getboolean(section, 'verify') if p.has_option(section, 'verify') else True
+        verify = p.get(section, 'verify') if p.has_option(section, 'verify') else True
         cert = p.get(section, 'cert') if p.has_option(section, 'cert') else None
 
         result[section] = {'username': username,


### PR DESCRIPTION
In the case of self-signed certs for internally hosted instances of Artifactory the requests API needs to be given the CACert file. This is achieved by using the verify param in the requests API to specify the path of the CA/Root Certificate chain.